### PR TITLE
feat: Expand testing matrix and improve package robustness

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,7 +10,9 @@ jobs:
   run_pytest:
     name: pytest
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+documentation = "https://github.com/drew2a/sentry-scrubber/blob/main/README.md"
 
 [tool.pytest.ini_options]
 pythonpath = [
     "sentry_scrubber", "."
 ]
-
 
 [tool.poetry.dependencies]
 python = "^3.9.17"

--- a/sentry_scrubber/__init__.py
+++ b/sentry_scrubber/__init__.py
@@ -1,3 +1,8 @@
-from importlib.metadata import version
+def get_version():
+    try:
+        from importlib.metadata import version
+        return version("sentry-scrubber")
+    except ImportError:
+        return "1.0.0"
 
-__version__ = version("sentry-scrubber")
+__version__ = get_version()

--- a/sentry_scrubber/tests/test_init.py
+++ b/sentry_scrubber/tests/test_init.py
@@ -1,0 +1,15 @@
+from unittest.mock import Mock, patch
+
+
+@patch('importlib.metadata.version', new=Mock(return_value="2.0.0"))
+def test_version_success():
+    """ Test version function """
+    from sentry_scrubber import get_version
+    assert get_version() == "2.0.0"
+
+
+@patch('importlib.metadata.version', new=Mock(side_effect=ImportError))
+def test_version_import_error():
+    """ Test version function with ImportError """
+    from sentry_scrubber import get_version
+    assert get_version() == "1.0.0"


### PR DESCRIPTION
Expanded the Python version matrix in GitHub Actions to include versions 3.9 through 3.12 for more comprehensive testing. Added a fallback mechanism in `__init__.py` to handle potential ImportError when fetching the package version, ensuring that the package remains robust even if importlib.metadata is not available. Also, added documentation link in `pyproject.toml` for better project understanding and accessibility.