### PR TITLE
feat: support custom sensitive strings in scrubber

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sentry-scrubber"
-version = "2.2.0"
+version = "2.3.0"
 description = "A lightweight and flexible Python library for scrubbing sensitive information from Sentry events before they are sent to the server."
 authors = ["Andrei Andreev"]
 readme = "README.md"

--- a/sentry_scrubber/scrubber.py
+++ b/sentry_scrubber/scrubber.py
@@ -100,13 +100,15 @@ class SentryScrubber:
         if self.scrub_hash:
             self._re_hash = re.compile(r'\b[0-9a-f]{40}\b', re.I)
 
-    def scrub_event(self, event: Optional[Dict[str, Any]], _=None) -> Optional[Dict[str, Any]]:
+    def scrub_event(self, event: Optional[Dict[str, Any]], _=None, sensitive_strings: Set[str] = None) \
+            -> Optional[Dict[str, Any]]:
         """
         Main method to scrub a Sentry event by removing sensitive and unnecessary information.
 
         Args:
             event (dict): A Sentry event represented as a dictionary.
-            _ (Any, optional): Unused parameter for compatibility. Defaults to None.
+            _ (Any, optional): Hint. Unused parameter for compatibility. Defaults to None.
+            sensitive_strings (set): A set contains all sensitive strings. Defaults to None.
 
         Returns:
             dict: The scrubbed Sentry event.
@@ -123,13 +125,15 @@ class SentryScrubber:
             delete_item(event, field_name)
 
         # remove sensitive information
-        sensitive_strings = set(self.sensitive_strings)
+        initial_sensitive_strings = set(self.sensitive_strings)
+        if sensitive_strings:
+            initial_sensitive_strings.update(sensitive_strings)
 
-        scrubbed_event = self.scrub_entity_recursively(event, sensitive_strings)
+        scrubbed_event = self.scrub_entity_recursively(event, initial_sensitive_strings)
 
         # this second call is necessary to complete the entities scrubbing
         # which were found at the end of the previous call
-        scrubbed_event = self.scrub_entity_recursively(scrubbed_event, sensitive_strings)
+        scrubbed_event = self.scrub_entity_recursively(scrubbed_event, initial_sensitive_strings)
 
         return scrubbed_event
 

--- a/sentry_scrubber/tests/test_scrubber.py
+++ b/sentry_scrubber/tests/test_scrubber.py
@@ -471,3 +471,15 @@ def test_is_dict_should_be_scrubbed_with_none_value():
     scrubber = SentryScrubber(dict_markers_to_scrub={"key": None})
     assert not scrubber._is_dict_should_be_scrubbed("key", None)
     assert not scrubber._is_dict_should_be_scrubbed("key", "not_none")
+
+
+def test_scrub_with_hint(scrubber: SentryScrubber):
+    """ Test that the scrubber does not break if hint is provided"""
+    actual = scrubber.scrub_event({'any': 'value'}, {})
+    assert actual == {'any': 'value'}
+
+
+def test_scrub_with_sensitive_strings(scrubber: SentryScrubber):
+    """ Test that the scrubber does not break if sensitive_strings is provided"""
+    actual = scrubber.scrub_event({'any': 'value'}, {}, {'value'})
+    assert actual == {'any': scrubber.placeholder}


### PR DESCRIPTION
Allows passing additional sensitive strings for scrubbing, improving flexibility when redacting data from Sentry events. Adds tests to ensure compatibility with optional parameters and expected placeholder replacement. Increments version to 2.3.0.